### PR TITLE
The "transformBundle" hook is deprecated. The "renderChunk" hook shou…

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ export default function es3ify(options = {}) {
 	return {
 		name: 'es3ify',
 
-		transformBundle(code) {
+		renderChunk(code) {
 			options.fromString = true;
 			delete options.inSourceMap;
 			delete options.outSourceMap;


### PR DESCRIPTION
The "transformBundle" hook used by plugin es3ify is deprecated. The "renderChunk" hook should be used instead.